### PR TITLE
Add distributed build logic in configuration.nix

### DIFF
--- a/system/configuration.nix
+++ b/system/configuration.nix
@@ -124,7 +124,7 @@
     hostName = "remote-builder";
     system = "x86_64-linux";
     protocol = "ssh-ng";
-    maxJobs = 1;
+    maxJobs = 3;
     speedFactor = 2;
     supportedFeatures = [ "nixos-test" "benchmark" "big-parallel" "kvm" ];
     mandatoryFeatures = [ ];

--- a/system/configuration.nix
+++ b/system/configuration.nix
@@ -121,10 +121,10 @@
   };
 
   nix.buildMachines = [{
-    hostName = "remotebuild.ryleu.me:2222";
+    hostName = "remote-builder";
     system = "x86_64-linux";
     protocol = "ssh-ng";
-    maxJobs = 0;
+    maxJobs = 1;
     speedFactor = 2;
     supportedFeatures = [ "nixos-test" "benchmark" "big-parallel" "kvm" ];
     mandatoryFeatures = [ ];
@@ -134,6 +134,14 @@
   nix.settings = {
     builders-use-substitutes = true;
   };
+
+    programs.ssh.extraConfig = ''
+      Host remote-builder
+        User nixremote
+        HostName remotebuild.ryleu.me
+        Port 2222
+        IdentityFile /home/user/.ssh/builder-rsa # As before, Agenix will work here
+    '';
 
   system.stateVersion = "25.05";
 }

--- a/system/configuration.nix
+++ b/system/configuration.nix
@@ -140,7 +140,6 @@
         User nixremote
         HostName remotebuild.ryleu.me
         Port 2222
-        IdentityFile /home/user/.ssh/builder-rsa # As before, Agenix will work here
     '';
 
   system.stateVersion = "25.05";

--- a/system/configuration.nix
+++ b/system/configuration.nix
@@ -120,5 +120,20 @@
     ];
   };
 
+  nix.buildMachines = [{
+    hostName = "remotebuild.ryleu.me:2222";
+    system = "x86_64-linux";
+    protocol = "ssh-ng";
+    maxJobs = 0;
+    speedFactor = 2;
+    supportedFeatures = [ "nixos-test" "benchmark" "big-parallel" "kvm" ];
+    mandatoryFeatures = [ ];
+  }];
+
+  nix.distributedBuilds = true;
+  nix.settings = {
+    builders-use-substitutes = true;
+  };
+
   system.stateVersion = "25.05";
 }


### PR DESCRIPTION
Clients will need to ```su && ssh-copy-id remote-builder``` before running a build.