### PR TITLE
feat: add VS Code Server support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -81,6 +81,24 @@
         "type": "github"
       }
     },
+    "flake-utils_3": {
+      "inputs": {
+        "systems": "systems_4"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "hardware": {
       "locked": {
         "lastModified": 1762463231,
@@ -174,6 +192,20 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1682134069,
+        "narHash": "sha256-TnI/ZXSmRxQDt2sjRYK/8j8iha4B4zP2cnQCZZ3vp7k=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fd901ef4bf93499374c5af385b2943f5801c0833",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
     "root": {
       "inputs": {
         "agenix": "agenix",
@@ -184,7 +216,8 @@
         "nixpkgs": [
           "nix-ros-overlay",
           "nixpkgs"
-        ]
+        ],
+        "vscode-server": "vscode-server"
       }
     },
     "systems": {
@@ -229,6 +262,40 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_4": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "vscode-server": {
+      "inputs": {
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1770124655,
+        "narHash": "sha256-yHmd2B13EtBUPLJ+x0EaBwNkQr9LTne1arLVxT6hSnY=",
+        "owner": "nix-community",
+        "repo": "nixos-vscode-server",
+        "rev": "92ce71c3ba5a94f854e02d57b14af4997ab54ef0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixos-vscode-server",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,7 @@
         darwin.follows = "";
       };
     };
+    vscode-server.url = "github:nix-community/nixos-vscode-server";
   };
 
   outputs =
@@ -33,6 +34,7 @@
       home-manager,
       basestation-cameras,
       hardware,
+      vscode-server,
       ...
     }:
     let

--- a/lib/mkHost.nix
+++ b/lib/mkHost.nix
@@ -25,6 +25,10 @@ let
     inputs.home-manager.nixosModules.home-manager
     inputs.nix-ros-overlay.nixosModules.default
     inputs.agenix.nixosModules.default
+    inputs.vscode-server.nixosModules.default
+    ({ config, pkgs, ... }: {
+      services.vscode-server.enable = true;
+    })
     ../system
     {
       networking.hostName = name;

--- a/lib/mkHost.nix
+++ b/lib/mkHost.nix
@@ -26,9 +26,12 @@ let
     inputs.nix-ros-overlay.nixosModules.default
     inputs.agenix.nixosModules.default
     inputs.vscode-server.nixosModules.default
-    ({ config, pkgs, ... }: {
-      services.vscode-server.enable = true;
-    })
+    (
+      { ... }:
+      {
+        services.vscode-server.enable = true;
+      }
+    )
     ../system
     {
       networking.hostName = name;


### PR DESCRIPTION
NixOS's lack of support for dynamically linked libraries breaks the Node.JS binary supplied with the VS Code Server. The service replaces it with a patched one or something I'm not really sure but I'm running it on Clucky and she works.